### PR TITLE
ci: fix linux execute permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
           mkdir output
           mkdir output/libimobiledevice
           cp build/*.bin output/
+          chmod +x output/*.bin
           cp config.yaml output/
           cp *route.txt output/
           cp -r DeveloperDiskImage output/


### PR DESCRIPTION
当前的main.bin的权限是rw-r--r--，要用chmod给用户执行权限。这样才可以直接执行./main.bin